### PR TITLE
Add repository for pterodactyl docker container images under the "Other Performance Tips" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ Other Performance Tips
 
 - Close everything in the background, including Discord, game launchers and your browser! Minecraft is resource intensive, and does not like other apps generating CPU interrupts or eating disk I/O, RAM and so on.  
 
-- Server Owners using the [pterodactyl panel](https://pterodactyl.io/) should check out [these docker container images](https://github.com/Software-Noob/pterodactyl-images/tree/main)! They contain a bunch of java distrobutions including GraalVM which work with Minecraft Servers.
+- Server Owners using the [pterodactyl panel](https://pterodactyl.io/) should check out [these docker container images](https://github.com/Software-Noob/pterodactyl-images/tree/main)! They contain a bunch of java distributions including GraalVM which work with Minecraft Servers.
 
 FAQ
 ======

--- a/README.md
+++ b/README.md
@@ -283,6 +283,8 @@ Other Performance Tips
 
 - Close everything in the background, including Discord, game launchers and your browser! Minecraft is resource intensive, and does not like other apps generating CPU interrupts or eating disk I/O, RAM and so on.  
 
+- Server Owners using the [pterodactyl panel](https://pterodactyl.io/) should check out [these docker container images](https://github.com/Software-Noob/pterodactyl-images/tree/main)! They contain a bunch of java distrobutions including GraalVM which work with Minecraft Servers.
+
 FAQ
 ======
 


### PR DESCRIPTION
Added a link to https://github.com/Software-Noob/pterodactyl-images/tree/main which contains a bunch of java distributions for use with the pterodactyl panel.